### PR TITLE
Fix crash when rect has negative width

### DIFF
--- a/LNICoverFlowLayout/Classes/LNICoverFlowLayout.swift
+++ b/LNICoverFlowLayout/Classes/LNICoverFlowLayout.swift
@@ -200,12 +200,12 @@ public class LNICoverFlowLayout:UICollectionViewFlowLayout {
         let cvW = collectionViewWidth()
         
         // Find min and max rows that can be determined for sure
-        var minRow = Int(max(rect.origin.x/cvW, 0))
+        var minRow = min(max(Int(rect.origin.x/cvW), 0), noI - 1)
         var maxRow = 0
         if cvW != 0 {
-            maxRow = Int(CGRectGetMaxX(rect) / cvW)
+            maxRow = min(Int(rect.maxX / cvW), noI - 1)
         }
-        
+
         // Additional check for rows that also can be included (our rows are moving depending on content size)
         let candidateMinRow = max(minRow-1, 0)
         
@@ -214,7 +214,7 @@ public class LNICoverFlowLayout:UICollectionViewFlowLayout {
         }
         
         let candidateMaxRow = min(maxRow + 1, noI - 1)
-        if minXForRow(candidateMaxRow) <= CGRectGetMaxX(rect) {
+        if minXForRow(candidateMaxRow) <= rect.maxX {
             maxRow = candidateMaxRow
         }
         

--- a/LNICoverFlowLayout_Demo/Pods/LNICoverFlowLayout/LNICoverFlowLayout/Classes/LNICoverFlowLayout.swift
+++ b/LNICoverFlowLayout_Demo/Pods/LNICoverFlowLayout/LNICoverFlowLayout/Classes/LNICoverFlowLayout.swift
@@ -200,12 +200,12 @@ public class LNICoverFlowLayout:UICollectionViewFlowLayout {
         let cvW = collectionViewWidth()
         
         // Find min and max rows that can be determined for sure
-        var minRow = Int(max(rect.origin.x/cvW, 0))
+        var minRow = min(max(Int(rect.origin.x/cvW), 0), noI - 1)
         var maxRow = 0
         if cvW != 0 {
-            maxRow = Int(CGRectGetMaxX(rect) / cvW)
+            maxRow = min(Int(rect.maxX / cvW), noI - 1)
         }
-        
+
         // Additional check for rows that also can be included (our rows are moving depending on content size)
         let candidateMinRow = max(minRow-1, 0)
         
@@ -214,7 +214,7 @@ public class LNICoverFlowLayout:UICollectionViewFlowLayout {
         }
         
         let candidateMaxRow = min(maxRow + 1, noI - 1)
-        if minXForRow(candidateMaxRow) <= CGRectGetMaxX(rect) {
+        if minXForRow(candidateMaxRow) <= rect.maxX {
             maxRow = candidateMaxRow
         }
         


### PR DESCRIPTION
I have iOS10, when scroll deep to right rect.width can become negative, probably iOS issue. And in this case minRow becomes equal to number of items and greater than maxRow, and it crashed here: `for i in minRow...maxRow {`. Could it replicate both in your example and in my application. 

Also removed legacy CGRectGet ...